### PR TITLE
Force merge overloaded method

### DIFF
--- a/lib/orthoses/content/duplication_checker.rb
+++ b/lib/orthoses/content/duplication_checker.rb
@@ -10,16 +10,22 @@ module Orthoses
       def update_decl
         return unless @decl.respond_to?(:members)
         uniq_map = {}
+        overloads = []
         @decl.members.each do |member|
-          key = member_key(member)
-          drop_member = uniq_map[key]
-          uniq_map[key] = member
-          if drop_member
-            Orthoses.logger.info("#{@decl.name} \"#{member.location.source}\" was droped since duplication")
+          if member.instance_of?(RBS::AST::Members::MethodDefinition) && member.overload
+            overloads << member
+          else
+            key = member_key(member)
+            drop_member = uniq_map[key]
+            uniq_map[key] = member
+            if drop_member
+              Orthoses.logger.info("#{@decl.name} \"#{member.location.source}\" was droped since duplication")
+            end
           end
         end
         drop_known_method_definition(uniq_map)
         @decl.members.replace(uniq_map.values)
+        @decl.members.concat(overloads)
       end
 
       private

--- a/lib/orthoses/content/duplication_checker_test.rb
+++ b/lib/orthoses/content/duplication_checker_test.rb
@@ -17,6 +17,10 @@ module DuplicationCheckerTest
         attr_reader baz: untyped # ok
         attr_writer baz: untyped # ok
 
+        def qux: () -> String # ok
+        def qux: (String) -> Integer # ok
+               | ...
+
         include Bar # remove
         include Bar # ok
       end
@@ -45,7 +49,11 @@ module DuplicationCheckerTest
         attr_reader baz: untyped
         attr_writer baz: untyped
 
+        def qux: () -> String
+
         include Bar
+        def qux: (String) -> Integer
+               | ...
       end
     RBS
     unless expect == actual


### PR DESCRIPTION
Fixes a problem in which methods with overload are judged as duplicates and eliminated when loaded with LoadRBS.