### PR TITLE
Fix ununiq methods

### DIFF
--- a/lib/orthoses/content.rb
+++ b/lib/orthoses/content.rb
@@ -27,16 +27,13 @@ module Orthoses
       @body = []
       @header = nil
       @comment = nil
-      @uniq = false
     end
 
     def <<(line)
-      @uniq = false
       @body << line
     end
 
     def concat(other)
-      @uniq = false
       @body.concat(other)
     end
 
@@ -49,7 +46,6 @@ module Orthoses
     end
 
     def delete(val)
-      @uniq = false
       @body.delete(val)
     end
 
@@ -115,10 +111,7 @@ module Orthoses
       end
       parsed_decl = parsed_decls.first or raise
       parsed_decl.tap do |decl|
-        if !@uniq
-          DuplicationChecker.new(decl).update_decl
-          @uniq = true
-        end
+        DuplicationChecker.new(decl).update_decl
       end
     rescue RBS::ParsingError
       Orthoses.logger.error "```rbs\n#{original_rbs}```"

--- a/lib/orthoses/content_test.rb
+++ b/lib/orthoses/content_test.rb
@@ -115,6 +115,29 @@ module ContentTest
     unless content.body == ["def foo: () -> void"]
       t.error("expect unique body, but got #{content.body.inspect}")
     end
+
+    content << "def foo: () -> void"
+    content.uniq!
+    unless content.body == ["def foo: () -> void"]
+      t.error("expect unique body, but got #{content.body.inspect}")
+    end
+  end
+
+  def test_direct_edit_body_on_uniq!(t)
+    content = Orthoses::Content.new(name: "Uniq")
+    content.header = "module Uniq"
+    content.body << "def foo: () -> void"
+    content.body << "def foo: () -> void"
+    content.uniq!
+    unless content.body == ["def foo: () -> void"]
+      t.error("expect unique body, but got #{content.body.inspect}")
+    end
+
+    content.body << "def foo: () -> void"
+    content.uniq!
+    unless content.body == ["def foo: () -> void"]
+      t.error("expect unique body, but got #{content.body.inspect}")
+    end
   end
 
   def test_comment(t)


### PR DESCRIPTION
Failure occurs when `@body` is manipulated directly.
Maybe `@body` shouldn't be able to operate.