### PR TITLE
Rename option for destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ For example, You can write script in Rakefile.
 require 'orthoses'
 
 namespace :rbs do
-  desc "build RBS to sig/out"
+  desc "build RBS to sig/orthoses"
   task :build do
     Orthoses::Builder.new do
       use Orthoses::CreateFileByName,
         depth: 1,
-        base_dir: Rails.root.join("sig/out"),
+        to: "sig/orthoses",
+        rmtree: true,
         header: "# !!! GENERATED CODE !!!"
       use Orthoses::Filter do |name, _content|
         path, _lineno = Object.const_source_location(name)
@@ -54,7 +55,7 @@ namespace :rbs do
 end
 ```
 
-Then, you can see the result files under `sig/out`.
+Then, you can see the result files under `sig/orthoses`.
 
 ## Utils
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ task :sig do
   Orthoses.logger.level = :info
   Orthoses::Builder.new do
     use Orthoses::CreateFileByName,
-      base_dir: 'sig',
+      to: 'sig',
       header: "# THIS IS GENERATED CODE from `$ rake sig`"
     use Orthoses::Filter do |name, _|
       name.start_with?("Orthoses")

--- a/examples/minitest/Rakefile
+++ b/examples/minitest/Rakefile
@@ -12,7 +12,7 @@ task :minitest => :src do
 
   Orthoses::Builder.new do
     use Orthoses::CreateFileByName,
-      base_dir: out.to_s
+      to: out.to_s
     use Orthoses::Filter do |name, content|
       name.start_with?("Minitest") || name == "Kernel"
     end

--- a/examples/rack-test/generate.rb
+++ b/examples/rack-test/generate.rb
@@ -9,7 +9,7 @@ out.rmtree rescue nil
 Orthoses.logger.level = :warn
 Orthoses::Builder.new do
   use Orthoses::CreateFileByName,
-    base_dir: out.to_s
+    to: out.to_s
   # use Orthoses::Sort
   use Orthoses::Filter do |name, content|
     name.start_with?("Rack::Test")

--- a/integration_test/active_support_test.rb
+++ b/integration_test/active_support_test.rb
@@ -2,7 +2,7 @@ module ActiveSupportTest
   def test_active_support(t)
     Orthoses::Builder.new do
       use Orthoses::CreateFileByName,
-        base_dir: 'integration_test/tmp'
+        to: 'integration_test/tmp'
       use Orthoses::Filter do |name, content|
         name.start_with?("ActiveSupport") || name.start_with?("Integer")
       end

--- a/known_sig/orthoses/create_file_by_name.rbs
+++ b/known_sig/orthoses/create_file_by_name.rbs
@@ -1,7 +1,7 @@
 module Orthoses
   class CreateFileByName
     @loader: Orthoses::_Call
-    def initialize: (Orthoses::_Call loader, base_dir: String, ?header: String?, ?depth: Integer?, ?rmtree: boolish) -> void
+    def initialize: (Orthoses::_Call loader, to: String, ?header: String?, ?depth: Integer?, ?rmtree: boolish) -> void
     def call: () -> Orthoses::store
   end
 end

--- a/lib/orthoses/create_file_by_name_test.rb
+++ b/lib/orthoses/create_file_by_name_test.rb
@@ -36,7 +36,7 @@ module CreateFileByNameTest
           store["Object"] << "include OutputableTest"
         end
       },
-      base_dir: "tmp",
+      to: "tmp",
       header: "# header"
     ).call
 

--- a/sig/orthoses/create_file_by_name.rbs
+++ b/sig/orthoses/create_file_by_name.rbs
@@ -1,7 +1,7 @@
 # THIS IS GENERATED CODE from `$ rake sig`
 
 class Orthoses::CreateFileByName
-  def initialize: (Orthoses::_Call loader, base_dir: String, ?header: String?, ?depth: Integer?, ?rmtree: boolish) -> void
+  def initialize: (Orthoses::_Call loader, to: String, ?header: String?, ?depth: Integer?, ?rmtree: boolish) -> void
   def call: () -> Orthoses::store
   @loader: Orthoses::_Call
 end


### PR DESCRIPTION
With `base_dir` it is hard to know what base it is. Use `to` instead.