### PR TITLE
Support Enumerable by untyped type params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 

--- a/lib/orthoses/mixin.rb
+++ b/lib/orthoses/mixin.rb
@@ -59,13 +59,17 @@ module Orthoses
 
           next if mod_name.start_with?("Orthoses")
 
-          known_type_params = Utils.known_type_params(mod)
-          next unless known_type_params.nil? || known_type_params.empty?
+          type_params_sig = ""
+          if type_params = Utils.known_type_params(mod)
+            if !type_params.empty?
+              type_params_sig = "[#{type_params.map{"untyped"}.join(", ")}]"
+            end 
+          end
 
           next unless @if.nil? || @if.call(base_mod, how, mod)
 
-          store[mod_name]
-          content << "#{how} #{mod_name}"
+          store[mod_name].header = "module #{mod_name}"
+          content << "#{how} #{mod_name}#{type_params_sig}"
         end
       end
     end

--- a/lib/orthoses/mixin.rb
+++ b/lib/orthoses/mixin.rb
@@ -50,6 +50,7 @@ module Orthoses
 
         base_mod_name = Utils.module_name(base_mod)
         next unless base_mod_name
+        next if base_mod_name.include?("#")
 
         content = store[base_mod_name]
         capture.argument[:modules].each do |mod|

--- a/lib/orthoses/mixin_test.rb
+++ b/lib/orthoses/mixin_test.rb
@@ -9,6 +9,7 @@ module MixinTest
       extend Mod
       prepend Mod
       include Module.new
+      include Enumerable
     end
     class ::Object
       include Mod
@@ -32,6 +33,7 @@ module MixinTest
     expect = <<~RBS
       class MixinTest::Foo
         include MixinTest::Mod
+        include Enumerable[untyped]
         extend MixinTest::Mod
         prepend MixinTest::Mod
       end


### PR DESCRIPTION
`Mixin` middleware set `include Enumerable[untyped]` when hook `include Enumerable`.