### PR TITLE
Order the types and method/attribute definitions generated by Orthoses::Trace

### DIFF
--- a/known_sig/orthoses/trace/attribute.rbs
+++ b/known_sig/orthoses/trace/attribute.rbs
@@ -2,6 +2,9 @@ module Orthoses
   class Trace
     class Attribute
       include Orthoses::Trace::Targetable
+
+      def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+      def call: () -> Orthoses::store
     end
   end
 end

--- a/known_sig/orthoses/trace/method.rbs
+++ b/known_sig/orthoses/trace/method.rbs
@@ -2,6 +2,9 @@ module Orthoses
   class Trace
     class Method
       include Orthoses::Trace::Targetable
+
+      def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+      def call: () -> Orthoses::store
     end
   end
 end

--- a/lib/orthoses/trace/attribute.rb
+++ b/lib/orthoses/trace/attribute.rb
@@ -23,9 +23,10 @@ module Orthoses
 
       include Targetable
 
-      def initialize(loader, patterns:)
+      def initialize(loader, patterns:, sort_union_types: true)
         @loader = loader
         @patterns = patterns
+        @sort_union_types = sort_union_types
 
         @captured_dict = Hash.new { |h, k| h[k] = Hash.new { |hh, kk| hh[kk] = [] } }
       end
@@ -44,8 +45,9 @@ module Orthoses
           end
 
         @captured_dict.each do |mod_name, captures|
-          captures.sort.each do |(kind, prefix, name), types|
-            injected = Utils::TypeList.new(types.sort).inject
+          captures.each do |(kind, prefix, name), types|
+            types.sort! if @sort_union_types
+            injected = Utils::TypeList.new(types).inject
             store[mod_name] << "#{kind} #{prefix}#{name}: #{injected}"
           end
         end

--- a/lib/orthoses/trace/attribute.rb
+++ b/lib/orthoses/trace/attribute.rb
@@ -44,8 +44,8 @@ module Orthoses
           end
 
         @captured_dict.each do |mod_name, captures|
-          captures.each do |(kind, prefix, name), types|
-            injected = Utils::TypeList.new(types).inject
+          captures.sort.each do |(kind, prefix, name), types|
+            injected = Utils::TypeList.new(types.sort).inject
             store[mod_name] << "#{kind} #{prefix}#{name}: #{injected}"
           end
         end

--- a/lib/orthoses/trace/method.rb
+++ b/lib/orthoses/trace/method.rb
@@ -77,9 +77,9 @@ module Orthoses
       def build_method_definitions
         untyped = ::RBS::Types::Bases::Any.new(location: nil)
 
-        @args_return_map.map do |(mod_name, kind, visibility, method_id), type_samples|
+        @args_return_map.sort_by {|key, _| key.join }.map do |(mod_name, kind, visibility, method_id), type_samples|
           type_samples.uniq!
-          method_types = type_samples.map do |(op_name_types, return_type)|
+          method_types = type_samples.sort.map do |(op_name_types, return_type)|
             required_positionals = []
             optional_positionals = []
             rest = nil

--- a/lib/orthoses/trace/method.rb
+++ b/lib/orthoses/trace/method.rb
@@ -7,9 +7,10 @@ module Orthoses
       Info = Struct.new(:key, :op_name_types, :raised, keyword_init: true)
       include Targetable
 
-      def initialize(loader, patterns:)
+      def initialize(loader, patterns:, sort_union_types: true)
         @loader = loader
         @patterns = patterns
+        @sort_union_types = sort_union_types
 
         @stack = []
         @args_return_map = Hash.new { |h, k| h[k] = [] }
@@ -77,9 +78,10 @@ module Orthoses
       def build_method_definitions
         untyped = ::RBS::Types::Bases::Any.new(location: nil)
 
-        @args_return_map.sort_by {|key, _| key.join }.map do |(mod_name, kind, visibility, method_id), type_samples|
+        @args_return_map.map do |(mod_name, kind, visibility, method_id), type_samples|
           type_samples.uniq!
-          method_types = type_samples.sort.map do |(op_name_types, return_type)|
+          type_samples.sort! if @sort_union_types
+          method_types = type_samples.map do |(op_name_types, return_type)|
             required_positionals = []
             optional_positionals = []
             rest = nil

--- a/lib/orthoses/trace/method_test.rb
+++ b/lib/orthoses/trace/method_test.rb
@@ -44,6 +44,15 @@ module TraceMethodTest
         end
       end
 
+      def multi_types(key)
+        {
+          0 => 0,
+          1 => '1',
+          '2' => '2',
+          '3' => 3,
+        }[key]
+      end
+
       private
 
       def priv(bool)
@@ -86,13 +95,13 @@ module TraceMethodTest
     actual = store.map { |n, c| c.to_rbs }.join("\n")
     expect = <<~RBS
       class TraceMethodTest::M
-        private def initialize: (Integer a) -> void
         def a_ten: () -> Integer
         def b_ten: (Integer b) -> Integer
-        private def priv: (bool bool) -> (Integer | Symbol)
         def call_priv: (bool c) -> (Integer | Symbol)
         def dele: (*Array[bool] a, **Hash[untyped, untyped]) -> Integer
         def if_raise: (bool a) -> String
+        private def initialize: (Integer a) -> void
+        private def priv: (bool bool) -> (Integer | Symbol)
         def self.singleton_method?: () -> bool
         alias c_ten a_ten
         alias self.alias_singleton_method? self.singleton_method?
@@ -130,5 +139,37 @@ module TraceMethodTest
       raise rescue nil
       Orthoses::Utils.new_store
     }, patterns: ['TraceMethodTest']).call
+  end
+
+  def test_order(t)
+    store1 = Orthoses::Trace::Method.new(->{
+      LOADER_METHOD.call
+      m = M.new(100)
+      m.a_ten
+      m.multi_types 0
+      m.multi_types 1
+      m.multi_types '2'
+      m.multi_types '3'
+
+      Orthoses::Utils.new_store
+    }, patterns: ['TraceMethodTest::M']).call
+
+    store2 = Orthoses::Trace::Method.new(->{
+      LOADER_METHOD.call
+      m = M.new(100)
+      m.multi_types '3'
+      m.multi_types '2'
+      m.multi_types 1
+      m.multi_types 0
+      m.a_ten
+
+      Orthoses::Utils.new_store
+    }, patterns: ['TraceMethodTest::M']).call
+
+    expect = store1.map { _2.to_rbs }.join("\n")
+    actual = store2.map { _2.to_rbs }.join("\n")
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    end
   end
 end

--- a/sig/orthoses/trace.rbs
+++ b/sig/orthoses/trace.rbs
@@ -10,9 +10,10 @@ end
 class Orthoses::Trace::Attribute
   @loader: untyped
   @patterns: untyped
+  @sort_union_types: untyped
   @captured_dict: untyped
-  def initialize: (untyped loader, patterns: untyped) -> void
-  def call: () -> untyped
+  def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+  def call: () -> Orthoses::store
   private def build_trace_hook: () -> untyped
   include Orthoses::Trace::Targetable
 end
@@ -30,11 +31,12 @@ end
 class Orthoses::Trace::Method
   @loader: untyped
   @patterns: untyped
+  @sort_union_types: untyped
   @stack: untyped
   @args_return_map: untyped
   @alias_map: untyped
-  def initialize: (untyped loader, patterns: untyped) -> void
-  def call: () -> untyped
+  def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+  def call: () -> Orthoses::store
   private def build_trace_point: () -> untyped
   private def build_members: () -> untyped
   private def build_method_definitions: () -> untyped


### PR DESCRIPTION
Since the Orthoses::Trace build type definitions from runtime information, they could be ordered differently depending on how they were called. I want to make it a bit more stable to make it less noisy and debugging easier.