### PR TITLE
Use Class#attached_object instead of Regex to support customized `#inspect` methods

### DIFF
--- a/known_sig/orthoses/utils.rbs
+++ b/known_sig/orthoses/utils.rbs
@@ -10,6 +10,7 @@ module Orthoses
     def self.object_to_rbs: (untyped object, ?strict: bool) -> String
     def self.module_name: (Module mod) -> String?
     def self.module_to_type_name: (Module) -> RBS::TypeName?
+    def self.attached_module_name: (Module) -> String?
     def self.known_type_params: (Module | String) -> Array[RBS::AST::TypeParam]?
     def self.new_store: () -> Orthoses::store
   end

--- a/lib/orthoses/trace/method.rb
+++ b/lib/orthoses/trace/method.rb
@@ -36,9 +36,8 @@ module Orthoses
           case tp.event
           when :call
             if tp.defined_class.singleton_class?
-              # e.g. `Minitest::Spec::DSL#to_s`` may return `nil` with `#to_s`
-              m = tp.defined_class.to_s&.match(/#<Class:([\w:]+)>/) or next
-              mod_name = m[1] or next
+              attached_object = tp.defined_class.attached_object
+              mod_name = (attached_object&.is_a?(Module) && attached_object.name) or next
               kind = :singleton
             else
               mod_name = Utils.module_name(tp.defined_class) or next

--- a/lib/orthoses/trace/method.rb
+++ b/lib/orthoses/trace/method.rb
@@ -36,8 +36,7 @@ module Orthoses
           case tp.event
           when :call
             if tp.defined_class.singleton_class?
-              attached_object = tp.defined_class.attached_object
-              mod_name = (attached_object&.is_a?(Module) && attached_object.name) or next
+              mod_name = Utils.attached_module_name(tp.defined_class) or next
               kind = :singleton
             else
               mod_name = Utils.module_name(tp.defined_class) or next

--- a/lib/orthoses/trace/method_test.rb
+++ b/lib/orthoses/trace/method_test.rb
@@ -54,7 +54,13 @@ module TraceMethodTest
         end
       end
     end
+
+    class CustomClassInspect
+      def self.inspect = "it's customized"
+      def self.a = 1
+    end
   }
+
   def test_method(t)
     store = Orthoses::Trace::Method.new(->{
       LOADER_METHOD.call
@@ -90,6 +96,26 @@ module TraceMethodTest
         def self.singleton_method?: () -> bool
         alias c_ten a_ten
         alias self.alias_singleton_method? self.singleton_method?
+      end
+    RBS
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    end
+  end
+
+  def test_custom_inspect(t)
+    store = Orthoses::Trace::Method.new(->{
+      LOADER_METHOD.call
+
+      CustomClassInspect.a
+
+      Orthoses::Utils.new_store
+    }, patterns: ['TraceMethodTest::CustomClassInspect']).call
+
+    actual = store.map { |n, c| c.to_rbs }.join("\n")
+    expect = <<~RBS
+      class TraceMethodTest::CustomClassInspect
+        def self.a: () -> Integer
       end
     RBS
     unless expect == actual

--- a/lib/orthoses/trace/method_test.rb
+++ b/lib/orthoses/trace/method_test.rb
@@ -103,23 +103,25 @@ module TraceMethodTest
     end
   end
 
-  def test_custom_inspect(t)
-    store = Orthoses::Trace::Method.new(->{
-      LOADER_METHOD.call
+  if Class.instance_methods.include?(:attached_object)
+    def test_custom_inspect(t)
+      store = Orthoses::Trace::Method.new(->{
+        LOADER_METHOD.call
 
-      CustomClassInspect.a
+        CustomClassInspect.a
 
-      Orthoses::Utils.new_store
-    }, patterns: ['TraceMethodTest::CustomClassInspect']).call
+        Orthoses::Utils.new_store
+      }, patterns: ['TraceMethodTest::CustomClassInspect']).call
 
-    actual = store.map { |n, c| c.to_rbs }.join("\n")
-    expect = <<~RBS
-      class TraceMethodTest::CustomClassInspect
-        def self.a: () -> Integer
+      actual = store.map { |n, c| c.to_rbs }.join("\n")
+      expect = <<~RBS
+        class TraceMethodTest::CustomClassInspect
+          def self.a: () -> Integer
+        end
+      RBS
+      unless expect == actual
+        t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
       end
-    RBS
-    unless expect == actual
-      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
     end
   end
 

--- a/lib/orthoses/utils.rb
+++ b/lib/orthoses/utils.rb
@@ -171,6 +171,17 @@ module Orthoses
       end
     end
 
+    def self.attached_module_name(mod)
+      if mod.respond_to?(:attached_object)
+        attached_object = mod.attached_object
+        (attached_object&.is_a?(Module) && attached_object.name) || nil
+      else
+        # e.g. `Minitest::Spec::DSL#to_s` may return `nil` with `#to_s`
+        m = mod.to_s&.match(/#<Class:([\w:]+)>/)
+        m && m[1]
+      end
+    end
+
     def self.known_type_params(name)
       type_name =
         case name

--- a/sig/orthoses/utils.rbs
+++ b/sig/orthoses/utils.rbs
@@ -21,6 +21,8 @@ module Orthoses::Utils
 
   def self.module_to_type_name: (Module) -> RBS::TypeName?
 
+  def self.attached_module_name: (Module) -> String?
+
   def self.known_type_params: (Module | String) -> Array[RBS::AST::TypeParam]?
 
   def self.new_store: () -> Orthoses::store


### PR DESCRIPTION
Some classes (for example, model classes that inherited ActiveRecord::Base) could return a bit unusual string when its `inspect` method is called like `User (call 'User.connection' to establish a connection)`. As a result, the `tp.defined_class.to_s` here could be different value from what we expect (like `#<Class:User (call 'User.connection' to establish a connection)>`). I think we can fix it by using `Class#attached_object`.
