### PR TITLE
Allow a callable object as the :patterns option of the Trace middleware

### DIFF
--- a/known_sig/orthoses/trace.rbs
+++ b/known_sig/orthoses/trace.rbs
@@ -1,7 +1,7 @@
 module Orthoses
   class Trace
     interface _CallablePatterns
-      def call: (String, TracePoint) -> bool
+      def call: (String, TracePoint) -> boolish
     end
 
     def initialize: (Orthoses::_Call loader, patterns: Array[String] | _CallablePatterns, ?sort_union_types: bool?) -> void

--- a/known_sig/orthoses/trace.rbs
+++ b/known_sig/orthoses/trace.rbs
@@ -1,0 +1,10 @@
+module Orthoses
+  class Trace
+    interface _CallablePatterns
+      def call: (String, TracePoint) -> bool
+    end
+
+    def initialize: (Orthoses::_Call loader, patterns: Array[String] | _CallablePatterns, ?sort_union_types: bool?) -> void
+    def call: () -> Orthoses::store
+  end
+end

--- a/known_sig/orthoses/trace/attribute.rbs
+++ b/known_sig/orthoses/trace/attribute.rbs
@@ -3,7 +3,7 @@ module Orthoses
     class Attribute
       include Orthoses::Trace::Targetable
 
-      def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+      def initialize: (Orthoses::_Call loader, patterns: Array[String] | Orthoses::Trace::_CallablePatterns, ?sort_union_types: bool?) -> void
       def call: () -> Orthoses::store
     end
   end

--- a/known_sig/orthoses/trace/method.rbs
+++ b/known_sig/orthoses/trace/method.rbs
@@ -3,7 +3,7 @@ module Orthoses
     class Method
       include Orthoses::Trace::Targetable
 
-      def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+      def initialize: (Orthoses::_Call loader, patterns: Array[String] | Orthoses::Trace::_CallablePatterns, ?sort_union_types: bool?) -> void
       def call: () -> Orthoses::store
     end
   end

--- a/lib/orthoses/trace.rb
+++ b/lib/orthoses/trace.rb
@@ -7,14 +7,15 @@ module Orthoses
     autoload :Method, 'orthoses/trace/method'
     autoload :Targetable, 'orthoses/trace/targetable'
 
-    def initialize(loader, patterns:)
+    def initialize(loader, patterns:, sort_union_types: true)
       @loader = loader
       @patterns = patterns
+      @sort_union_types = sort_union_types
     end
 
     def call
-      @loader = Trace::Attribute.new(@loader, patterns: @patterns)
-      @loader = Trace::Method.new(@loader, patterns: @patterns)
+      @loader = Trace::Attribute.new(@loader, patterns: @patterns, sort_union_types: @sort_union_types)
+      @loader = Trace::Method.new(@loader, patterns: @patterns, sort_union_types: @sort_union_types)
       @loader.call
     end
   end

--- a/lib/orthoses/trace/attribute.rb
+++ b/lib/orthoses/trace/attribute.rb
@@ -64,7 +64,7 @@ module Orthoses
             mod_name = m[1]
           end
           next unless mod_name
-          next unless target?(mod_name)
+          next unless target?(mod_name, tp1)
           is_singleton = tp1.self.singleton_class?
           prefix = is_singleton ? "self." : ""
           kind = tp1.method_id

--- a/lib/orthoses/trace/attribute_test.rb
+++ b/lib/orthoses/trace/attribute_test.rb
@@ -119,4 +119,27 @@ module TraceAttributeTest
       t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
     end
   end
+
+  def test_pattern_proc(t)
+    patterns = ->(name, tp) { tp.self.name == "TraceAttributeTest::Foo" }
+    store = Orthoses::Trace::Attribute.new(->{
+      LOADER_ATTRIBUTE.call
+      foo = Foo.new
+      foo.attr_read_publ
+      Foo::Bar.new.attr_acce_publ = /reg/
+
+      Orthoses::Utils.new_store
+    }, patterns: patterns).call
+
+    actual = store.map { |n, c| c.to_rbs }.join("\n")
+    expect = <<~RBS
+      class TraceAttributeTest::Foo
+        attr_accessor attr_acce_priv: Integer
+        attr_reader attr_read_publ: Symbol
+      end
+    RBS
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    end
+  end
 end

--- a/lib/orthoses/trace/method.rb
+++ b/lib/orthoses/trace/method.rb
@@ -44,7 +44,7 @@ module Orthoses
               kind = :instance
             end
 
-            next unless target?(mod_name)
+            next unless target?(mod_name, tp)
 
             visibility = tp.self.private_methods.include?(tp.method_id) ? :private : nil
             key = [mod_name, kind, visibility, tp.method_id]

--- a/lib/orthoses/trace/method_test.rb
+++ b/lib/orthoses/trace/method_test.rb
@@ -134,6 +134,31 @@ module TraceMethodTest
     end
   end
 
+  def test_pattern_proc(t)
+    # only non-private methods
+    patterns = ->(name, tp) { name == "TraceMethodTest::M" && !tp.self.private_methods.include?(tp.method_id) }
+    store = Orthoses::Trace::Method.new(-> {
+      LOADER_METHOD.call
+
+      m = M.new(100)
+      m.a_ten
+      m.call_priv(true)
+
+      Orthoses::Utils.new_store
+    }, patterns: patterns).call
+
+    actual = store.map { |n, c| c.to_rbs }.join("\n")
+    expect = <<~RBS
+      class TraceMethodTest::M
+        def a_ten: () -> Integer
+        def call_priv: (bool c) -> Integer
+      end
+    RBS
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    end
+  end
+
   def test_raise_first(t)
     Orthoses::Trace::Method.new(->{
       raise rescue nil

--- a/lib/orthoses/trace/targetable.rb
+++ b/lib/orthoses/trace/targetable.rb
@@ -3,12 +3,16 @@
 module Orthoses
   class Trace
     module Targetable
-      def target?(name)
-        @patterns.any? do |pattern|
-          if pattern.end_with?("*")
-            (name || "").start_with?(pattern.chop)
-          else
-            name == pattern
+      def target?(name, tp)
+        if @patterns.respond_to?(:call)
+          @patterns.call(name, tp)
+        else
+          @patterns.any? do |pattern|
+            if pattern.end_with?("*")
+              (name || "").start_with?(pattern.chop)
+            else
+              name == pattern
+            end
           end
         end
       end

--- a/sig/orthoses/trace.rbs
+++ b/sig/orthoses/trace.rbs
@@ -4,7 +4,7 @@ class Orthoses::Trace
   @loader: untyped
   @patterns: untyped
   @sort_union_types: untyped
-  def initialize: (Orthoses::_Call loader, patterns: Array[String | _CallablePatterns], ?sort_union_types: bool?) -> void
+  def initialize: (Orthoses::_Call loader, patterns: Array[String] | _CallablePatterns, ?sort_union_types: bool?) -> void
   def call: () -> Orthoses::store
 end
 
@@ -13,7 +13,7 @@ class Orthoses::Trace::Attribute
   @patterns: untyped
   @sort_union_types: untyped
   @captured_dict: untyped
-  def initialize: (Orthoses::_Call loader, patterns: Array[String | Orthoses::Trace::_CallablePatterns], ?sort_union_types: bool?) -> void
+  def initialize: (Orthoses::_Call loader, patterns: Array[String] | Orthoses::Trace::_CallablePatterns, ?sort_union_types: bool?) -> void
   def call: () -> Orthoses::store
   private def build_trace_hook: () -> untyped
   include Orthoses::Trace::Targetable
@@ -36,7 +36,7 @@ class Orthoses::Trace::Method
   @stack: untyped
   @args_return_map: untyped
   @alias_map: untyped
-  def initialize: (Orthoses::_Call loader, patterns: Array[String | Orthoses::Trace::_CallablePatterns], ?sort_union_types: bool?) -> void
+  def initialize: (Orthoses::_Call loader, patterns: Array[String] | Orthoses::Trace::_CallablePatterns, ?sort_union_types: bool?) -> void
   def call: () -> Orthoses::store
   private def build_trace_point: () -> untyped
   private def build_members: () -> untyped
@@ -53,5 +53,5 @@ module Orthoses::Trace::Targetable
 end
 
 interface Orthoses::Trace::_CallablePatterns
-  def call: (String, TracePoint) -> bool
+  def call: (String, TracePoint) -> boolish
 end

--- a/sig/orthoses/trace.rbs
+++ b/sig/orthoses/trace.rbs
@@ -3,8 +3,9 @@
 class Orthoses::Trace
   @loader: untyped
   @patterns: untyped
-  def initialize: (untyped loader, patterns: untyped) -> void
-  def call: () -> untyped
+  @sort_union_types: untyped
+  def initialize: (Orthoses::_Call loader, patterns: Array[String | _CallablePatterns], ?sort_union_types: bool?) -> void
+  def call: () -> Orthoses::store
 end
 
 class Orthoses::Trace::Attribute
@@ -12,7 +13,7 @@ class Orthoses::Trace::Attribute
   @patterns: untyped
   @sort_union_types: untyped
   @captured_dict: untyped
-  def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+  def initialize: (Orthoses::_Call loader, patterns: Array[String | Orthoses::Trace::_CallablePatterns], ?sort_union_types: bool?) -> void
   def call: () -> Orthoses::store
   private def build_trace_hook: () -> untyped
   include Orthoses::Trace::Targetable
@@ -35,7 +36,7 @@ class Orthoses::Trace::Method
   @stack: untyped
   @args_return_map: untyped
   @alias_map: untyped
-  def initialize: (Orthoses::_Call loader, patterns: Array[String], ?sort_union_types: bool?) -> void
+  def initialize: (Orthoses::_Call loader, patterns: Array[String | Orthoses::Trace::_CallablePatterns], ?sort_union_types: bool?) -> void
   def call: () -> Orthoses::store
   private def build_trace_point: () -> untyped
   private def build_members: () -> untyped
@@ -48,5 +49,9 @@ class Orthoses::Trace::Method::Info < ::Struct[untyped]
 end
 
 module Orthoses::Trace::Targetable
-  def target?: (untyped name) -> untyped
+  def target?: (untyped name, untyped tp) -> untyped
+end
+
+interface Orthoses::Trace::_CallablePatterns
+  def call: (String, TracePoint) -> bool
 end


### PR DESCRIPTION
I'd like to pass a Proc as the `patterns` option for the Trace middleware because I sometimes want to filter classes by a bit different conditions like filtering by the file path (TracePoint#path) rather than module name matching. This change allows users to pass an object that responds to `:call` as the `:patterns` option similar to Orthoses::RBSPrototypeRuntime.