### PR TITLE
Allow Orthoses::Constant to skip modules

### DIFF
--- a/lib/orthoses/constant.rb
+++ b/lib/orthoses/constant.rb
@@ -30,6 +30,7 @@ module Orthoses
             cache[[current, const]] = true
 
             if val.kind_of?(Module)
+              next unless @if.nil? || @if.call(current, const, val, nil)
               will_add_key_and_content << [Utils.module_name(val), nil]
               next
             end

--- a/lib/orthoses/constant_test.rb
+++ b/lib/orthoses/constant_test.rb
@@ -13,6 +13,7 @@ module ConstantTest
     end
     class Baz
       CONST = 3
+      IGNORE_ME = Class.new
     end
   end
 
@@ -21,7 +22,7 @@ module ConstantTest
       Orthoses::Utils.new_store.tap do |store|
         store["ConstantTest"]
       end
-    }, strict: true).call
+    }, strict: true, if: -> (current, const, val, rbs) { const.to_s != "IGNORE_ME" }).call
 
     unless store.length == 8
       t.error("expect 8 constant decls, but got #{store.length}")


### PR DESCRIPTION
I noticed that modules cannot be skipped. This patch aims to fix it.